### PR TITLE
Correction CSS alignement des ul sur le bloc left

### DIFF
--- a/assets/css/Style.css
+++ b/assets/css/Style.css
@@ -139,17 +139,15 @@ header h3 {
 #about .left__doc__p__langage {
     margin-top: 20px;
     width: 290px;
-    margin-left: 20px;
+    margin-left: -20px;
     font-size: .9rem;
-    word-break: break-all;
 }
 
 #about .left__doc__p__interest {
     margin-top: 20px;
     width: 290px;
-    margin-left: 20px;
+    margin-left: -20px;
     font-size: .9rem;
-    word-break: break-all;
 }
 
 /* ******************DEBUT RIGHT DOC ********************** */


### PR DESCRIPTION
Sur le CSS alignement des ul sur le bloc left 

Code avant correction : 

#about .left__doc__p__langage {
    margin-top: 20px;
    width: 290px;
    margin-left: 20px;
    font-size: .9rem;
}

#about .left__doc__p__interest {
    margin-top: 20px;
    width: 290px;
    margin-left: 20px;
    font-size: .9rem;
}

Code après correction : 

#about .left__doc__p__langage {
    margin-top: 20px;
    width: 290px;
    margin-left: -20px;
    font-size: .9rem;
}

#about .left__doc__p__interest {
    margin-top: 20px;
    width: 290px;
    margin-left: -20px;
    font-size: .9rem;
}

